### PR TITLE
add Getting Started section to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,11 @@ With out of the box support for event sourcing, and a considered implementation 
 
 Nact is no silver bullet, but it is evolving to tackle ever more demanding use cases. Perhaps one of them is yours?
 
-To get started, head to https://nact.io
+## Getting started
+
+Run `npm install --save reason-nact` and add `reason-nact` to the `bs-dependencies` in `bsconfig.json`. 
+
+Full documentation at https://nact.io
 
 ## License
 [![FOSSA Status](https://app.fossa.io/api/projects/git%2Bgithub.com%2Fncthbrt%2Freason-nact.svg?type=large)](https://app.fossa.io/projects/git%2Bgithub.com%2Fncthbrt%2Freason-nact?ref=badge_large)


### PR DESCRIPTION
This helps with quick lookup. You don't always need the full documentation,a nd it took me three clicks and a lot of scanning text just to find out how to install it.

I like to name this section "Installation", but it seemed more fitting to name it "Getting Started", so it flows better into the link to the full documentation.

I won't take offense if you change and move things around, the point is just having the information easily available :)